### PR TITLE
feat: dynamically import globby

### DIFF
--- a/src/infrastructure/scanner/FileScanner.ts
+++ b/src/infrastructure/scanner/FileScanner.ts
@@ -1,7 +1,6 @@
 import { Scanner, RepoInfo } from '../../domain/ports';
 import { Evidence } from '../../domain/models';
 import { URL_REGEX, IPV4_REGEX, IPV6_REGEX } from './extractors';
-import { globby } from 'globby';
 import { isBinary } from 'istextorbinary';
 import fs from 'fs';
 import path from 'path';
@@ -28,6 +27,7 @@ export class FileScanner implements Scanner {
   }
 
   async scanRepo(repo: RepoInfo): Promise<Evidence[]> {
+    const { globby } = await import('globby');
     const git = simpleGit(repo.path);
     let commitSha = '';
     try {


### PR DESCRIPTION
## Summary
- lazy-load globby in FileScanner.scanRepo to avoid top-level import

## Testing
- `npm run build`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a0cfb1aa4c832dac130e1bd264b205